### PR TITLE
fix frame number issue in the image output names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,164 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# ignore data files
+data/
+.DS_Store

--- a/custom/gen_csv.ipynb
+++ b/custom/gen_csv.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 140,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import re\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_folders_in_directory(directory):\n",
+    "    folders = [f for f in os.listdir(directory) if os.path.isdir(os.path.join(directory, f))]\n",
+    "    return folders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 142,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def list_files_in_directory(directory):\n",
+    "    files = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]\n",
+    "    return files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 143,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_info_from_name(img_file_name):\n",
+    "    # Extract numeric values using regular expression, last two represent width and height\n",
+    "    numeric_values = [int(match) for match in re.findall(r'\\d+', img_file_name)]\n",
+    "    return numeric_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "video_name = \"video-00002-2020_04_26_11_57_51\"\n",
+    "root = \"C:/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/\"\n",
+    "root_sub = root+video_name + '/' + video_name + '/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(columns=['day_dir',\n",
+    "                           'camera_dir',\n",
+    "                           'video_dir',\n",
+    "                           'track_dir',\n",
+    "                           'directory',\n",
+    "                           'image_file',\n",
+    "                           'count',\n",
+    "                           'frame',\n",
+    "                           'x',\n",
+    "                           'y',\n",
+    "                           'speed',\n",
+    "                           'area',\n",
+    "                           'id',\n",
+    "                           'bird',\n",
+    "                           'cable',\n",
+    "                           'panel',\n",
+    "                           'plant',\n",
+    "                           'car',\n",
+    "                           'human',\n",
+    "                           'other_animal',\n",
+    "                           'insect',\n",
+    "                           'aircraft',\n",
+    "                           'other',\n",
+    "                           'unknown',\n",
+    "                           'shadow_reflection',\n",
+    "                           'fly_over_above',\n",
+    "                           'fly_over_reflection',\n",
+    "                           'fly_through',\n",
+    "                           'perch_on_panel',\n",
+    "                           'land_on_ground',\n",
+    "                           'perch_in_background',\n",
+    "                           'collision',\n",
+    "                           'image_count',\n",
+    "                           'obj_cat',\n",
+    "                           'obj_cat_binary',\n",
+    "                           'activity_cat',\n",
+    "                           'obj_id',\n",
+    "                           'ttv_split',\n",
+    "                           'ttv_split_act'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2, 2020, 4, 26, 11, 57, 51, 2, 1, 2829, 420, 48, 9366, 1152, 101, 2786, 393, 86, 54]\n",
+      "1\n",
+      "2829\n",
+      "420\n",
+      "2786\n",
+      "393\n"
+     ]
+    }
+   ],
+   "source": [
+    "# v2, frame, x, y\n",
+    "tmp = extract_info_from_name('video-00002-2020_04_26_11_57_51_v2_1_2829_420_48.09366_1152_101_2786_393_86_54.png')\n",
+    "print(tmp)\n",
+    "print(tmp[8]) # frame num\n",
+    "print(tmp[9]) # x\n",
+    "print(tmp[10]) # y\n",
+    "print(tmp[15]) # ux\n",
+    "print(tmp[16]) # uy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate CSV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get list of all images\n",
+    "tracks = get_folders_in_directory(root_sub) # get all tracks\n",
+    "for track in tracks:\n",
+    "    imgs = list_files_in_directory(root_sub+track) # get all images in a track\n",
+    "    frames = [extract_info_from_name(item)[8] for item in imgs]\n",
+    "    x_coord = [extract_info_from_name(item)[15] for item in imgs]\n",
+    "    y_coord = [extract_info_from_name(item)[16] for item in imgs]\n",
+    "    speed = [extract_info_from_name(item)[11] for item in imgs]\n",
+    "    area = [extract_info_from_name(item)[12] for item in imgs]\n",
+    "    track_id = [extract_info_from_name(item)[13] for item in imgs]\n",
+    "    tmp = pd.DataFrame({'day_dir':None,\n",
+    "                        'camera_dir':None,\n",
+    "                        'video_dir':video_name,\n",
+    "                        'track_dir':track,\n",
+    "                        'directory':'/'+video_name+'/'+track,\n",
+    "                        'image_file':imgs,\n",
+    "                        'count':1,\n",
+    "                        'frame':frames,\n",
+    "                        'x':x_coord,\n",
+    "                        'y':y_coord,\n",
+    "                        'speed':speed,\n",
+    "                        'area':area,\n",
+    "                        'id':track_id,\n",
+    "                        'bird':None,\n",
+    "                        'cable':None,\n",
+    "                        'panel':None,\n",
+    "                        'plant':None,\n",
+    "                        'car':None,\n",
+    "                        'human':None,\n",
+    "                        'other_animal':None,\n",
+    "                        'insect':None,\n",
+    "                        'aircraft':None,\n",
+    "                        'other':None,\n",
+    "                        'unknown':None,\n",
+    "                        'shadow_reflection':None,\n",
+    "                        'fly_over_above':None,\n",
+    "                        'fly_over_reflection':None,\n",
+    "                        'fly_through':None,\n",
+    "                        'perch_on_panel':None,\n",
+    "                        'land_on_ground':None,\n",
+    "                        'perch_in_background':None,\n",
+    "                        'collision':None,\n",
+    "                        'image_count':None,\n",
+    "                        'obj_cat':None,\n",
+    "                        'obj_cat_binary':None,\n",
+    "                        'activity_cat':None,\n",
+    "                        'obj_id':None,\n",
+    "                        'ttv_split':None,\n",
+    "                        'ttv_split_act':None\n",
+    "                    })\n",
+    "    df = pd.concat([df,tmp], ignore_index=True)\n",
+    "\n",
+    "df\n",
+    "df.to_csv(root+video_name+'/'+video_name+'.csv', index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "capstone",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/custom/track_gif.py
+++ b/custom/track_gif.py
@@ -1,0 +1,42 @@
+import os
+from PIL import Image
+import imageio
+
+def get_folders_in_directory(directory):
+    folders = [f for f in os.listdir(directory) if os.path.isdir(os.path.join(directory, f))]
+    return folders
+
+def create_gif(input_folder, output_gif):
+    images = []
+
+    # Ensure the output folder exists
+    os.makedirs(os.path.dirname(output_gif), exist_ok=True)
+
+    # Get a list of image files in the input folder
+    image_files = [f for f in os.listdir(input_folder) if f.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.bmp'))]
+
+    # Sort the image files to maintain order
+    image_files.sort()
+
+    # Read images and append to the list
+    for image_file in image_files:
+        image_path = os.path.join(input_folder, image_file)
+        img = Image.open(image_path)
+        images.append(img)
+
+    # Save the images as a GIF
+    imageio.mimsave(output_gif, images, duration=.5)  # Adjust the duration as needed
+
+if __name__ == "__main__":
+    video_name = "video-00030-2019_06_26_13_41_08/"
+    root = "C:/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/" + video_name
+    input_folder = root + video_name + video_name
+    tracks = get_folders_in_directory(input_folder)
+
+    print(tracks)
+
+    for i in tracks:
+        output_gif = root + video_name + i + '.gif'
+        print(output_gif)
+        create_gif(input_folder + i, output_gif)
+        print(f"GIF created at {output_gif}")

--- a/custom/write_image.ipynb
+++ b/custom/write_image.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,13 +24,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
     "def draw_rect(vid_path: str,\n",
-    "              image_path: str,\n",
-    "              image_name: str):\n",
+    "              image_name: str,\n",
+    "              out_filename: str):\n",
     "    '''\n",
     "    Function for generating an output on a frame in cv2\n",
     "    '''\n",
@@ -39,7 +39,7 @@
     "    \n",
     "    # draw rectangle given image\n",
     "    vals = extract_info_from_name(image_name)\n",
-    "    frm=5466\n",
+    "    frm = vals[8]\n",
     "\n",
     "    # Set the frame position (0-based index) of the frame you want to read\n",
     "    # Set the frame position using the set method\n",
@@ -49,7 +49,7 @@
     "    ret, frame = cap.read()\n",
     "\n",
     "    # Define the coordinates and color for the rectangle\n",
-    "    x, y, width, height = 2261, 482, vals[11], vals[12]  # Rectangle position and size\n",
+    "    x, y, width, height = vals[9], vals[10], vals[17], vals[18]  # Rectangle position and size\n",
     "\n",
     "    top_left = (int(x - width / 2), int(y - height / 2))\n",
     "    bottom_right = (int(x + width / 2), int(y + height / 2))\n",
@@ -58,14 +58,17 @@
     "    color = (0, 255, 0)  # Green color in BGR format\n",
     "    thickness = 2\n",
     "\n",
+    "    # add frame num to end of file name\n",
+    "    out_filename = out_filename + '_' + str(frm) + '.jpg'\n",
+    "\n",
     "    # Draw a rectangle on the frame, use converted coord\n",
     "    cv2.rectangle(frame, top_left, bottom_right, color, thickness)\n",
     "\n",
     "    # Draw the circle on the image center\n",
-    "    cv2.circle(frame, (x,y), 15, color, thickness)\n",
+    "    #cv2.circle(frame, (x,y), 15, color, thickness)\n",
     "\n",
     "    # Save the modified frame as an image\n",
-    "    cv2.imwrite('output_frame.jpg', frame)\n",
+    "    cv2.imwrite(out_filename, frame)\n",
     "\n",
     "    # Release the video capture object\n",
     "    cap.release()\n",
@@ -76,14 +79,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
     "vid_path = '/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/video-00002-2020_04_26_11_57_51.mkv'\n",
-    "image_path = '/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/video-00002-2020_04_26_11_57_51/video-00002-2020_04_26_11_57_51/306/video-00002-2020_04_26_11_57_51_v2_5466_2261_482_30.06659_257_306_2240_464_43_36.png'\n",
-    "image_name = 'video-00002-2020_04_26_11_57_51_v2_5466_2261_482_30.06659_257_306_2240_464_43_36.png'\n",
-    "draw_rect(vid_path, image_path, image_name)"
+    "image_name = 'video-00002-2020_04_26_11_57_51_v2_2404_569_782_0.00000_363_101_550_757_38_51'\n",
+    "draw_rect(vid_path, image_name, 'output')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "def draw_rect_track(vid_path, track_path, output_dir):\n",
+    "\n",
+    "    # Get the current working directory\n",
+    "    current_directory = os.getcwd()\n",
+    "\n",
+    "    # check if output path exists\n",
+    "    if not os.path.exists(output_dir):\n",
+    "        try:\n",
+    "            os.makedirs(output_dir)\n",
+    "            print(f\"Directory created: {output_dir}\")\n",
+    "        except OSError as e:\n",
+    "            print(f\"Error creating directory {output_dir}: {e}\")\n",
+    "    else:\n",
+    "        print(f\"Directory already exists: {output_dir}\")\n",
+    "\n",
+    "    # Change the working directory to the specified path\n",
+    "    os.chdir(output_dir)\n",
+    "\n",
+    "    # Get all files in the directory\n",
+    "    files = [f for f in os.listdir(track_path) if os.path.isfile(os.path.join(track_path, f))]\n",
+    "\n",
+    "    for i in files:\n",
+    "        draw_rect(vid_path, i, 'output')\n",
+    "\n",
+    "    # reset working directory\n",
+    "    os.chdir(current_directory)\n",
+    "\n",
+    "    print(files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Directory created: /Users/Aaron/Desktop/uchicago-aviansolar-detect-track/custom/track/\n",
+      "['video-00002-2020_04_26_11_57_51_v2_2414_400_778_17.33760_238_209_381_760_39_37.png', 'video-00002-2020_04_26_11_57_51_v2_2415_381_780_19.10497_169_209_362_764_39_33.png', 'video-00002-2020_04_26_11_57_51_v2_2416_365_782_16.12452_255_209_345_763_40_39.png', 'video-00002-2020_04_26_11_57_51_v2_2417_348_779_17.26268_160_209_330_762_36_34.png', 'video-00002-2020_04_26_11_57_51_v2_2418_330_778_18.02776_206_209_311_760_38_36.png', 'video-00002-2020_04_26_11_57_51_v2_2419_311_778_19.00000_160_209_293_761_37_34.png', 'video-00002-2020_04_26_11_57_51_v2_2420_293_780_18.11077_269_209_273_761_40_38.png', 'video-00002-2020_04_26_11_57_51_v2_2421_275_777_18.24829_159_209_257_760_36_34.png', 'video-00002-2020_04_26_11_57_51_v2_2422_257_774_18.24829_227_209_237_757_40_35.png', 'video-00002-2020_04_26_11_57_51_v2_2423_238_773_18.13978_227_209_237_757_40_35.png', 'video-00002-2020_04_26_11_57_51_v2_2424_217_778_22.32980_288_209_197_759_41_38.png']\n"
+     ]
+    }
+   ],
+   "source": [
+    "vid_path = '/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/video-00002-2020_04_26_11_57_51.mkv'\n",
+    "track_path ='/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/video-00002-2020_04_26_11_57_51/video-00002-2020_04_26_11_57_51/100'\n",
+    "output_dir = '/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/custom/track/'\n",
+    "draw_rect_track(vid_path, track_path, output_dir) "
    ]
   }
  ],

--- a/custom/write_image.ipynb
+++ b/custom/write_image.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2\n",
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_info_from_name(img_file_name):\n",
+    "    # Extract numeric values using regular expression, last two represent width and height\n",
+    "    numeric_values = [int(match) for match in re.findall(r'\\d+', img_file_name)]\n",
+    "    return numeric_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 152,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_rect(vid_path: str,\n",
+    "              image_path: str,\n",
+    "              image_name: str):\n",
+    "    '''\n",
+    "    Function for generating an output on a frame in cv2\n",
+    "    '''\n",
+    "    # read the video\n",
+    "    cap = cv2.VideoCapture(vid_path) \n",
+    "    \n",
+    "    # draw rectangle given image\n",
+    "    vals = extract_info_from_name(image_name)\n",
+    "    frm=5466\n",
+    "\n",
+    "    # Set the frame position (0-based index) of the frame you want to read\n",
+    "    # Set the frame position using the set method\n",
+    "    cap.set(cv2.CAP_PROP_POS_FRAMES, frm)\n",
+    "\n",
+    "    # read the first frame\n",
+    "    ret, frame = cap.read()\n",
+    "\n",
+    "    # Define the coordinates and color for the rectangle\n",
+    "    x, y, width, height = 2261, 482, vals[11], vals[12]  # Rectangle position and size\n",
+    "\n",
+    "    top_left = (int(x - width / 2), int(y - height / 2))\n",
+    "    bottom_right = (int(x + width / 2), int(y + height / 2))\n",
+    "\n",
+    "\n",
+    "    color = (0, 255, 0)  # Green color in BGR format\n",
+    "    thickness = 2\n",
+    "\n",
+    "    # Draw a rectangle on the frame, use converted coord\n",
+    "    cv2.rectangle(frame, top_left, bottom_right, color, thickness)\n",
+    "\n",
+    "    # Draw the circle on the image center\n",
+    "    cv2.circle(frame, (x,y), 15, color, thickness)\n",
+    "\n",
+    "    # Save the modified frame as an image\n",
+    "    cv2.imwrite('output_frame.jpg', frame)\n",
+    "\n",
+    "    # Release the video capture object\n",
+    "    cap.release()\n",
+    "\n",
+    "    # Close any OpenCV windows\n",
+    "    cv2.destroyAllWindows()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 153,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vid_path = '/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/video-00002-2020_04_26_11_57_51.mkv'\n",
+    "image_path = '/Users/Aaron/Desktop/uchicago-aviansolar-detect-track/data/video-00002-2020_04_26_11_57_51/video-00002-2020_04_26_11_57_51/306/video-00002-2020_04_26_11_57_51_v2_5466_2261_482_30.06659_257_306_2240_464_43_36.png'\n",
+    "image_name = 'video-00002-2020_04_26_11_57_51_v2_5466_2261_482_30.06659_257_306_2240_464_43_36.png'\n",
+    "draw_rect(vid_path, image_path, image_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "capstone",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/main_app_single_file.py
+++ b/main_app_single_file.py
@@ -35,9 +35,9 @@ def find_objects(file, filename, outpath, showImages, writeImages, writeVideoFil
             cv2.resizeWindow('contours', 1920, 1080)
 
     
-        count = 1
+        count = 4022
         # set this value if you want to start processing a video somewhere in the middle
-        start_frame_number = 0
+        start_frame_number = 4022
         cap.set(cv2.CAP_PROP_POS_FRAMES, start_frame_number)
         while cap.isOpened():
             t1 = time.perf_counter()
@@ -46,7 +46,10 @@ def find_objects(file, filename, outpath, showImages, writeImages, writeVideoFil
             if ret == False:
                 break
     
-            print("frame: " + str(count))
+            # print("frame: " + str(count))
+            if count in [12, 1031, 1032, 1040, 2340, 2414, 4022, 5036, 5429, 6265]:
+                print('frame: ' + str(count))
+
             if showImages | writeVideoFile:
                 orig_frame = copy.copy(frame)
             else:

--- a/tracker.py
+++ b/tracker.py
@@ -671,7 +671,7 @@ class Tracker(object):
                     if self.tracks[i].write_initial_frames == True:
                         # then write out all previous images, but do only once
                         self.tracks[i].write_initial_frames = False
-                        prev_frame_num = frame_num - len(self.tracks[i].images)
+                        prev_frame_num = frame_num - len(self.tracks[i].images) - 1
                         for k in range(len(self.tracks[i].images)):
                             px, py = self.tracks[i].trace[k]
                             parea = self.tracks[i].areas[k]

--- a/tracker.py
+++ b/tracker.py
@@ -138,7 +138,6 @@ class Tracker(object):
         if (width == 0) & (height == 0):
             return np.zeros([1, 1, 3], dtype=np.uint8)
 
-
         frameHeight = frame.shape[0]
         frameWidth = frame.shape[1]
 
@@ -671,7 +670,7 @@ class Tracker(object):
                     if self.tracks[i].write_initial_frames == True:
                         # then write out all previous images, but do only once
                         self.tracks[i].write_initial_frames = False
-                        prev_frame_num = frame_num - len(self.tracks[i].images) - 1
+                        prev_frame_num = frame_num - len(self.tracks[i].images)
                         for k in range(len(self.tracks[i].images)):
                             px, py = self.tracks[i].trace[k]
                             parea = self.tracks[i].areas[k]
@@ -680,13 +679,15 @@ class Tracker(object):
                             pvel_mag = np.sqrt(np.power(pspeed[0], 2) + np.power(pspeed[1], 2))
                             pvel_mag = self.tracks[i].distances[k]
                             # todo, figure out how to get frame_num of previous better
-                            self.writeImage(self.tracks[i].images[k], px, py, prev_frame_num, self.tracks[i].track_id, pvel_mag, parea, pux, puy, pbWidth, pbHeight)
+                            # AC: Images written in this path always have wrong frame num
+                            self.writeImage(self.tracks[i].images[k], px, py, prev_frame_num, str(self.tracks[i].track_id) + 'WRONG', pvel_mag, parea, pux, puy, pbWidth, pbHeight)
                             prev_frame_num += 1
-                            
+                    
                     ux, uy, bWidth, bHeight = self.tracks[i].boxes[-1]
                     speed = self.tracks[i].vel_prediction
                     vel_mag = np.sqrt(np.power(speed[0], 2) + np.power(speed[1], 2))
                     vel_mag = self.tracks[i].distances[-1]
+                    # AC: Images in this path sometimes have wrong frame num. frame num ahead of what is should be SOMETIMES. Seems to depend on when video processing is started.
                     self.writeImage(cropped_frame, x, y, frame_num, self.tracks[i].track_id, vel_mag, objArea, ux, uy, bWidth, bHeight)
 
             # only maintain history of a certain length


### PR DESCRIPTION
Issue in the image output name where the frame number value listed was offset by the track number.

For example: images in the 1st track generated had a frame number offset by 1, images in the 2nd track had a frame number offset by 2, and so on.

Fix implemented _shouldn't_ affect anything besides the frame number output in the file name as far as I can tell...